### PR TITLE
Show the actual argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use only the ad hoc query endpoint, `/server`, just start using:
     
 The following configuration parameters can be passed after the jar:
 
-* **--mcstatus.servers**
+* **--mcstatus.servers**=host[:port]
   
   A comma separated list of `host[:port]` to pre-configure for use with `/servers` endpoint 
 


### PR DESCRIPTION
Otherwise one might accidentaly spend 2-3 hours tracking down why the OneShotRunner is being run and not the service because i'm passing an IP as a separate argument from --mcstatus.servers. Totally not me. Promise.

Especially confusing since i've been using the minecraft-router now which has arguments in the format: `--argument value` and not `--argument=value`

Probably might want to give a proper message in the logs why a particular runner is being selected. 